### PR TITLE
Decode encoded path segments in urls

### DIFF
--- a/lib/route-recognizer.js
+++ b/lib/route-recognizer.js
@@ -297,7 +297,7 @@ function findHandler(state, path, queryParams) {
     var handler = handlers[i], names = handler.names, params = {};
 
     for (var j=0, m=names.length; j<m; j++) {
-      params[names[j]] = captures[currentCapture++];
+      params[names[j]] = decodeURIComponent(captures[currentCapture++]);
     }
 
     result.push({ handler: handler.handler, params: params, isDynamic: !!names.length });

--- a/tests/recognizer-tests.js
+++ b/tests/recognizer-tests.js
@@ -129,6 +129,26 @@ test("A dynamic route recognizes", function() {
   equal(router.recognize("/zoo/baz"), null);
 });
 
+test("A simple dynamic route with an encoded segment recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/:bar", handler: handler }]);
+
+  var bar = "abc/def";
+  var encodedBar = encodeURIComponent(bar);
+  resultsMatch(router.recognize("/foo/" + encodedBar), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
+});
+
+test("A complex dynamic route with an encoded segment recognizes", function() {
+  var handler = {};
+  var router = new RouteRecognizer();
+  router.add([{ path: "/foo/:bar/baz", handler: handler }]);
+
+  var bar = "abc/def";
+  var encodedBar = encodeURIComponent(bar);
+  resultsMatch(router.recognize("/foo/" + encodedBar + "/baz"), [{ handler: handler, params: { bar: bar }, isDynamic: true }]);
+});
+
 test("Multiple routes recognize", function() {
   var handler1 = { handler: 1 };
   var handler2 = { handler: 2 };


### PR DESCRIPTION
This allows handlers like "/foo/:bar" to match a path with a url encoded
segment such as "/foo/abc%Fdef" -> { params: { bar: "abc/def" } }

See related issue https://github.com/emberjs/ember.js/issues/11497
